### PR TITLE
fix(wezterm-nightly): fix x86_64 build cause it uses separate default sdk

### DIFF
--- a/pkgs/wezterm-nightly/default.nix
+++ b/pkgs/wezterm-nightly/default.nix
@@ -6,11 +6,7 @@
 }: let
   inherit (pkgs) fontconfig installShellFiles lib libGL libiconv libxkbcommon ncurses nixosTests openssl perl pkg-config python3 runCommand stdenv vulkan-loader wayland zlib;
   inherit (pkgs.xorg) libX11 libxcb xcbutil xcbutilimage xcbutilkeysyms xcbutilwm;
-  apple_sdk =
-    if pkgs.stdenv.isAarch64
-    then "apple_sdk"
-    else "apple_sdk_11_0";
-  inherit (pkgs.darwin.${apple_sdk}.frameworks) CoreGraphics Cocoa Foundation UserNotifications;
+  inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreGraphics Cocoa Foundation UserNotifications;
 in
   rustPlatform.buildRustPackage rec {
     pname = "wezterm";

--- a/pkgs/wezterm-nightly/default.nix
+++ b/pkgs/wezterm-nightly/default.nix
@@ -6,7 +6,11 @@
 }: let
   inherit (pkgs) fontconfig installShellFiles lib libGL libiconv libxkbcommon ncurses nixosTests openssl perl pkg-config python3 runCommand stdenv vulkan-loader wayland zlib;
   inherit (pkgs.xorg) libX11 libxcb xcbutil xcbutilimage xcbutilkeysyms xcbutilwm;
-  inherit (pkgs.darwin.apple_sdk.frameworks) CoreGraphics Cocoa Foundation UserNotifications;
+  apple_sdk =
+    if pkgs.stdenv.isAarch64
+    then "apple_sdk"
+    else "apple_sdk_11_0";
+  inherit (pkgs.darwin.${apple_sdk}.frameworks) CoreGraphics Cocoa Foundation UserNotifications;
 in
   rustPlatform.buildRustPackage rec {
     pname = "wezterm";


### PR DESCRIPTION
Subj.

For aarch64 nixpkgs tree uses apple_sdk_11_0 as a default, while x86_64 is stuck at 10.12 to maintain backwards compatibility with older macOS systems. PR makes this package build on x86_64 as well.

N.B. I assume, this will also work if (instead of `if` block) you simply change the line to
```nix
inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreGraphics Cocoa Foundation UserNotifications;
```
But I have no M1/2 box to test it.