### PR TITLE
fix(wezterm): build on x86_64-darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,5 +26,11 @@
   plymouth-theme-catppuccin = pkgs.callPackage ./pkgs/plymouth-theme-catppuccin {};
   swww = pkgs.callPackage ./pkgs/swww {};
   vscode-extensions.ms-kubernetes-tools.vscode-kubernetes-tools = pkgs.callPackage ./pkgs/vscode-extensions.ms-kubernetes-tools.vscode-kubernetes-tools {};
-  wezterm-nightly = pkgs.callPackage ./pkgs/wezterm-nightly {inherit wezterm-src craneLib;};
+  wezterm-nightly = pkgs.darwin.apple_sdk_11_0.callPackage ./pkgs/wezterm-nightly {
+    stdenv = with pkgs;
+      if stdenv.isDarwin
+      then darwin.apple_sdk_11_0.stdenv
+      else stdenv;
+    inherit wezterm-src craneLib;
+  };
 }

--- a/pkgs/wezterm-nightly/default.nix
+++ b/pkgs/wezterm-nightly/default.nix
@@ -2,8 +2,9 @@
   craneLib,
   pkgs,
   wezterm-src,
+  stdenv,
 }: let
-  inherit (pkgs) fontconfig installShellFiles lib libGL libiconv libxkbcommon ncurses nixosTests openssl perl pkg-config python3 runCommand stdenv vulkan-loader wayland zlib;
+  inherit (pkgs) fontconfig installShellFiles lib libGL libiconv libxkbcommon ncurses nixosTests openssl perl pkg-config python3 runCommand vulkan-loader wayland zlib;
   inherit (pkgs.xorg) libX11 libxcb xcbutil xcbutilimage xcbutilkeysyms xcbutilwm;
   inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreGraphics Cocoa Foundation UserNotifications;
 
@@ -41,11 +42,11 @@
       UserNotifications
     ];
   cargoArtifacts = craneLib.buildDepsOnly {
-    inherit src pname version nativeBuildInputs buildInputs;
+    inherit src pname version nativeBuildInputs buildInputs stdenv;
   };
 in
   craneLib.buildPackage rec {
-    inherit pname version cargoArtifacts nativeBuildInputs buildInputs;
+    inherit pname version cargoArtifacts nativeBuildInputs buildInputs stdenv;
     name = "${pname}-${version}";
     src = wezterm-src;
     doCheck = false;


### PR DESCRIPTION
Well apparently crane library you use inherits `pkgs.stdenv` somewhere which works fine for aarch64-darwin since it already uses apple_sdk_11_0 by default, but for x86_64 it actually breaks the system regardless of inputs you provided.

Luckily, you can just override... ;)